### PR TITLE
Expand test coverage for WOTS, Merkle, and XMSS

### DIFF
--- a/xmss_project/tests/test_merkle.py
+++ b/xmss_project/tests/test_merkle.py
@@ -24,6 +24,12 @@ class TestMerkle(unittest.TestCase):
         tampered_root = "12345"
         self.assertFalse(MerkleTree.verify_path(self.leaves[index], path, index, tampered_root))
 
+    def test_path_wrong_index(self):
+        index = 0
+        path = self.tree.get_path(index)
+        wrong_index = 1
+        self.assertFalse(MerkleTree.verify_path(self.leaves[index], path, wrong_index, self.tree.get_root()))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/xmss_project/tests/test_wots.py
+++ b/xmss_project/tests/test_wots.py
@@ -1,7 +1,7 @@
 # Unit tests for WOTS
 import unittest
 from src.wots import WOTS
-from src.config import XMSS_SEED
+from src.config import XMSS_SEED, WOTS_KEY_SIZE
 
 
 class TestWOTS(unittest.TestCase):
@@ -18,6 +18,17 @@ class TestWOTS(unittest.TestCase):
         signature = self.wots.sign(message)
         signature[0] = "tampered"
         self.assertFalse(self.wots.verify(message, signature))
+
+    def test_signature_length(self):
+        message = "length test"
+        signature = self.wots.sign(message)
+        self.assertEqual(len(signature), WOTS_KEY_SIZE)
+
+    def test_wrong_message_verification(self):
+        message = "original"
+        signature = self.wots.sign(message)
+        wrong_message = "modified"
+        self.assertFalse(self.wots.verify(wrong_message, signature))
 
 
 if __name__ == "__main__":

--- a/xmss_project/tests/test_xmss.py
+++ b/xmss_project/tests/test_xmss.py
@@ -1,5 +1,7 @@
 # Unit tests for XMSS
 import unittest
+import random
+import string
 from src.xmss import XMSS
 from src.encode import IncomparableEncoding
 from src.config import XMSS_SEED, XMSS_LEAVES
@@ -25,6 +27,26 @@ class TestXMSS(unittest.TestCase):
         signature = self.xmss.sign(1, message)
         signature["root"] = "tampered"
         self.assertFalse(self.xmss.verify(message, signature))
+
+    def test_sign_invalid_index(self):
+        message = IncomparableEncoding.encode_message("out of range")
+        with self.assertRaises(IndexError):
+            self.xmss.sign(XMSS_LEAVES, message)
+
+    def test_verify_wrong_message(self):
+        message = IncomparableEncoding.encode_message("correct")
+        signature = self.xmss.sign(2, message)
+        wrong_message = IncomparableEncoding.encode_message("incorrect")
+        self.assertFalse(self.xmss.verify(wrong_message, signature))
+
+    def test_sign_and_verify_random_messages(self):
+        random.seed(0)
+        alphabet = string.ascii_letters + string.digits
+        for idx in range(3):
+            msg_str = "".join(random.choices(alphabet, k=20))
+            message = IncomparableEncoding.encode_message(msg_str)
+            signature = self.xmss.sign(idx, message)
+            self.assertTrue(self.xmss.verify(message, signature))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add tests for WOTS signature length and wrong message verification
- add Merkle path wrong index test
- add XMSS invalid index, wrong message, and random message tests

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f941de944832a982675d401f09898